### PR TITLE
Update to Unity Hub 1.6.1

### DIFF
--- a/com.unity.UnityHub.appdata.xml
+++ b/com.unity.UnityHub.appdata.xml
@@ -21,7 +21,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
-    <release version="1.6.0" date="2019-03-07"/>
+    <release version="1.6.1" date="2019-04-16" />
   </releases>
   <content_rating type="oars-1.1">
     <content_attribute id="language-humor">mild</content_attribute>

--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -66,8 +66,8 @@ modules:
       - type: extra-data
         filename: UnityHubSetup.AppImage
         url: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHubSetup.AppImage
-        sha256: d5c97b45aac341917cfb238016b91a06862f20d8cb5f59c41cb7d8acdea1e7d2
-        size: 63150128
+        sha256: c521e2caf2ce8c8302cc9d8f385648c7d8c76ae29ac24ec0c0ffd3cd67a915fc
+        size: 63236599
       - type: file
         path: Unity.png
       - type: file


### PR DESCRIPTION
Guessing that it's date co-incided with the release of Unity 2019.1. Unity
Editor for Linux Preview, yay!