### PR TITLE
Update UnityHub version, fix installation error

### DIFF
--- a/com.unity.UnityHub.appdata.xml
+++ b/com.unity.UnityHub.appdata.xml
@@ -18,6 +18,7 @@
     <kudo>HiDpiIcon</kudo>
   </kudos>
   <releases>
+    <release version="2.2.2" date="2020-01-01"/>
     <release version="2.1.3" date="2019-10-23"/>
     <release version="2.1.2" date="2019-09-17"/>
     <release version="2.1.1" date="2019-09-05"/>

--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -76,8 +76,8 @@ modules:
       - type: extra-data
         filename: UnityHubSetup.AppImage
         url: https://public-cdn.cloud.unity3d.com/hub/prod/UnityHub.AppImage
-        sha256: 5f4dfe3fd646b0efea21b33d0d53da80459b4c7dd86180c8e32472bf80da6fb2
-        size: 60000352
+        sha256: ce82979bc6189d03e7b777e6b88a1cb8c7fb4fbf6eb4d07d6877bc48128ca7e7
+        size: 60025614
       - type: file
         path: Unity.png
       - type: file


### PR DESCRIPTION
Update to use the new UnityHub AppImage, the current flatpak package release fails to install, this fixes it.

I'm not too sure about the actual release date of this new UnityHub version, so I choose `2020-01-01`. I don't think this really matters though.

Fixes #25 