### PR TITLE
Allow all devices

### DIFF
--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -10,7 +10,7 @@ tags:
   - proprietary
 finish-args:
   - --allow=multiarch
-  - --device=dri
+  - --device=all
   - --filesystem=host
   - --share=ipc
   - --share=network


### PR DESCRIPTION
- required to access USB Devices to build for Android (adb)
- required to use all kinds of Game controllers

Closes #4
Closes #59