### PR TITLE
Run on discrete GPU, if available

### DIFF
--- a/com.unity.UnityHub.desktop
+++ b/com.unity.UnityHub.desktop
@@ -8,3 +8,4 @@ Icon=com.unity.UnityHub
 MimeType=x-scheme-handler/unityhub;
 Categories=Development;
 StartupWMClass=unityhub
+PrefersNonDefaultGPU=true


### PR DESCRIPTION
On systems where a more powerful secondary GPU is available, this key causes GNOME, KDE, and possibly other desktops to launch the app (by default) with an appropriate set of environment variables to use that GPU.  The assumption is that, as a gaming tool, Unity users probably want to use a discrete GPU if available.

Unity Hub itself probably won't care either way, but the Unity editor it spawns will, as will the games spawned by that editor.

https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#key-prefersnondefaultgpu