### PR TITLE
Update to 23.08 runtime

### DIFF
--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -1,8 +1,8 @@
 app-id: com.unity.UnityHub
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 command: start-unityhub
 separate-locales: false
@@ -26,13 +26,13 @@ finish-args:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '22.08'
+    version: '23.08'
   org.freedesktop.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: '22.08'
+    version: '23.08'
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: '22.08'
+    version: '23.08'
     add-ld-path: .
 modules:
   - name: compat


### PR DESCRIPTION
- [x] Launching 2021.3 hangs at “Initial Asset Database Refresh”
    - Upstream bug, marked WONTFIX