### PR TITLE
Revert "Revert "Update to 24.08 runtime""

### DIFF
--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -1,8 +1,8 @@
 app-id: com.unity.UnityHub
 base: org.electronjs.Electron2.BaseApp
-base-version: '23.08'
+base-version: '24.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 command: start-unityhub
 separate-locales: false
@@ -26,13 +26,13 @@ finish-args:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '23.08'
+    version: '24.08'
   org.freedesktop.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: '23.08'
+    version: '24.08'
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: '23.08'
+    version: '24.08'
     add-ld-path: .
 modules:
   - name: compat


### PR DESCRIPTION
This reverts commit ff67e1445775eb5cac284502fdb30ff06772a0bb, from #128.

Blocked by:

- [ ] https://github.com/flathub/com.unity.UnityHub/issues/125
- [ ] https://github.com/flathub/com.unity.UnityHub/issues/127