### PR TITLE
fix(unityhub.py): wrapper not passing arguments to unityhub

### DIFF
--- a/unityhub.py
+++ b/unityhub.py
@@ -64,7 +64,7 @@ def main():
     env['TMPDIR'] = f'{env["XDG_CACHE_HOME"]}/tmp'
 
     os.execvpe('zypak-wrapper',
-               ['zypak-wrapper', '/app/extra/unityhub-bin', *sys.argv[1:]],
+               ['zypak-wrapper', '/app/extra/unityhub-bin', '--', *sys.argv[1:]],
                env)
 
 


### PR DESCRIPTION
Fixes #126 

| before |
| --- |
| ![image](https://github.com/user-attachments/assets/10f3de29-2ecc-4344-acc1-8652113cee2a) |
| ![image](https://github.com/user-attachments/assets/0016330d-a92e-43f6-a218-e6a79f90f54a) |

| after |
| --- |
| ![image](https://github.com/user-attachments/assets/3c171710-8e7c-4ef1-acbd-eb26290fd939) |
| ![image](https://github.com/user-attachments/assets/5a816fa3-1f04-46b4-9e89-e9066763c34e) |
