### PR TITLE
Fix issue #41

### DIFF
--- a/vscode.py
+++ b/vscode.py
@@ -250,12 +250,13 @@ async def spawn_vscode(flatpak: Flatpak, editor: Editor, sdk: str, unity_port: i
     arch = sdk_info[1]
     branch = sdk_info[2]
 
-    missing_extensions: List[str] = []
     args: List[str] = []
     # the first element will mark the start index of the arguments that unity pass to the code editor
     # it will be equal to the size of our list plus 1, because bash script arguments index start at 1
     args.append("0")
     args.extend(editor.get_bash_arguments())
+
+    missing_extensions: List[str] = []
     for sdk_ext in 'org.freedesktop.Sdk.Extension.dotnet', 'org.freedesktop.Sdk.Extension.mono':
         ext = await flatpak.get_extension(sdk_ext, arch, branch)
         args.append(str(ext))


### PR DESCRIPTION
Fix issue #41 

Because of my mistake when accidentally deleting remote branch on my forked repository, the #148 was closed automatically.
I create this new PR to update the logic for the feedback, please check comment [3271176369](https://github.com/flathub/com.unity.UnityHub/pull/148#issuecomment-3271176369) for more details.
Anyway, the logic now is more future proof.
- Not use for any specific version of dotnet or mono, such as dotnet6, dotnet9, mono6, etc...
- Instead search for any installed runtime extension match the generic name `dotnet` and `mono` which is compatible with code editor architecture and branch
  - If there is, feed the extension name (no reference) to the vscode bash script
  - If there isn't, show the warning to user as usual