### PR TITLE
Add D-Bus and kwalletd6 talk names to UnityHub

### DIFF
--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -21,6 +21,8 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.Software
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --talk-name=org.freedesktop.DBus
+  - --talk-name=org.kde.kwalletd6
   # Delays sleep with reason “Application cleanup before suspend”.
   # Ideally it would use the inhibit portal, but here we are.
   - --system-talk-name=org.freedesktop.login1

--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -21,7 +21,6 @@ finish-args:
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.gnome.Software
   - --talk-name=org.kde.StatusNotifierWatcher
-  - --talk-name=org.freedesktop.DBus
   - --talk-name=org.kde.kwalletd6
   # Delays sleep with reason “Application cleanup before suspend”.
   # Ideally it would use the inhibit portal, but here we are.


### PR DESCRIPTION
Fix #176 

*This is untested!*
I edited the permissions using the gui in the system settings on my end, which worked. I assume this should work, but I didn't test it by building the flatpak and all that.