### PR TITLE
REFAC: Drop obsolete libsecret.json module reference

### DIFF
--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -42,7 +42,6 @@ modules:
       - mkdir -p /app/lib/i386-linux-gnu /app/lib/debug/lib/i386-linux-gnu
 
   - shared-modules/glu/glu-9.json
-  - shared-modules/libsecret/libsecret.json
   - openssl-1.1.yaml
 
   - name: unityhub


### PR DESCRIPTION
https://github.com/flathub/org.electronjs.Electron2.BaseApp/commit/cfb39a752f06e5c5a71c7a58141a199cc5568405 suggests the base runtime already includes it.

(Mostly a test to see if this affects authentication not being remembered somehow.)