### PR TITLE
fix: only set prefs if not already set

### DIFF
--- a/unityhub.py
+++ b/unityhub.py
@@ -27,8 +27,9 @@ def edit_pref(root, pref, type, func):
     else:
         return False
 
-def replace_string_pref(root, pref, value):
-    return edit_pref(root, pref, 'string', lambda _: value)
+
+def set_default_string_pref(root, pref, value):
+    return edit_pref(root, pref, 'string', lambda existing: existing if existing is not None else value)
 
 
 def main():
@@ -47,9 +48,9 @@ def main():
     root = tree.getroot()
 
     was_changed = any([
-        replace_string_pref(root, 'kScriptsDefaultApp', b64_editor),
-        replace_string_pref(root, 'kScriptEditorArgs', b64_args),
-        replace_string_pref(root, 'kScriptEditorArgs/app/bin/code', b64_args),
+        set_default_string_pref(root, 'kScriptsDefaultApp', b64_editor),
+        set_default_string_pref(root, 'kScriptEditorArgs', b64_args),
+        set_default_string_pref(root, 'kScriptEditorArgs/app/bin/code', b64_args),
     ])
 
     if was_changed:


### PR DESCRIPTION
The original implementation overwrites the preferences every time causing the selected code editor to be reset on every launch.

This fix should only override it if it has not already been set.