### PR TITLE
Disable Flathub breaking libxml2 update suggestions

### DIFF
--- a/libxml2.yaml
+++ b/libxml2.yaml
@@ -20,6 +20,7 @@ sources:
   - type: archive
     url: https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.9.tar.xz
     sha256: a2c9ae7b770da34860050c309f903221c67830c86e4a7e760692b803df95143a
-    x-checker-data:
-      type: gnome
-      name: libxml2
+    # Disabled for now as libxml > 2.13 breaks Unity editors.
+    # x-checker-data:
+    #   type: gnome
+    #   name: libxml2


### PR DESCRIPTION
They break the Unity Editor, see also https://github.com/flathub/com.unity.UnityHub/pull/199#issuecomment-4809182537.