### PR TITLE
Bump FreeDesktop runtime and SDK to 26.08

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ flatpak install mono
 ```
 
 And choose the variant matching the runtime of the Flatpak-ed IDE you use (e.g. if you use VSCode and it's using the
-FreeDesktop Runtime 25.08, install the .NET and Mono variants for 25.08).
+FreeDesktop Runtime 26.08, install the .NET and Mono variants for 26.08).
 
 You can choose the .NET SDK version that best matches your workflow and works with the language server you use in
 your IDE - usually they are pretty backwards compatible so using the latest .NET version tends to work well.

--- a/com.unity.UnityHub.yaml
+++ b/com.unity.UnityHub.yaml
@@ -1,8 +1,8 @@
 app-id: com.unity.UnityHub
 base: org.electronjs.Electron2.BaseApp
-base-version: '25.08'
+base-version: '26.08'
 runtime: org.freedesktop.Sdk
-runtime-version: '25.08'
+runtime-version: '26.08'
 sdk: org.freedesktop.Sdk
 command: start-unityhub
 separate-locales: false
@@ -28,13 +28,13 @@ finish-args:
 add-extensions:
   org.freedesktop.Platform.Compat.i386:
     directory: lib/i386-linux-gnu
-    version: '25.08'
+    version: '26.08'
   org.freedesktop.Platform.Compat.i386.Debug:
     directory: lib/debug/lib/i386-linux-gnu
-    version: '25.08'
+    version: '26.08'
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: '25.08'
+    version: '26.08'
     add-ld-path: .
 modules:
   - name: compat


### PR DESCRIPTION
Completely untested and to get the ball rolling.